### PR TITLE
encrypt.m: use matrices instead of separate variables

### DIFF
--- a/Encrypt.m
+++ b/Encrypt.m
@@ -1,19 +1,11 @@
-image=imread('image.jpg');
-image=im2double(image);
-layer1=image(:,:,1);
-layer2=image(:,:,2);
-layer3=image(:,:,3);
-key=imread('key.jpg');
-key=im2double(key);
-key1=key(:,:,1);
-key2=key(:,:,2);
-key3=key(:,:,3);
-layer1=key1*layer1;
-layer2=key2*layer2;
-layer3=key3*layer3;
-final(:,:,1)=layer1(:,:,1)
-final(:,:,2)=layer2(:,:,1)
-final(:,:,3)=layer3(:,:,1)
+image=im2double(imread('image.jpg'));
+layer = [image(:,:,1) image(:,:,2) image(:,:,3)]
+key = im2double(imread('key.jpg'))
+key = [key(:,:,1) key(:,:,2) key(:,:,3)]
+layer = [key[1]*layer[1] key[2]*layer[2] key[3]*layer[3]]
+final(:,:,1)=layer[1]
+final(:,:,2)=layer[2]
+final(:,:,3)=layer[3]
 final=final/100;
 figure (1);
 imshow(image)


### PR DESCRIPTION
use layer[] instead of layer1, layer2, layer3
use key[] instead of key1, key2, key3
remove redundant function calls