### PR TITLE
decrypt.m: use matrices instead of separate variables

### DIFF
--- a/Decrypt.m
+++ b/Decrypt.m
@@ -1,20 +1,12 @@
 load('Encrypted.mat');
-image=final;
-image=image*100;
-layer1=image(:,:,1);
-layer2=image(:,:,2);
-layer3=image(:,:,3);
-key=imread('key.jpg');
-key=im2double(key);
-key1=key(:,:,1);
-key2=key(:,:,2);
-key3=key(:,:,3);
-layer1=inv(key1)*layer1;
-layer2=inv(key2)*layer2;
-layer3=inv(key3)*layer3;
-final(:,:,1)=layer1(:,:,1);
-final(:,:,2)=layer2(:,:,1);
-final(:,:,3)=layer3(:,:,1);
+image = final * 100;
+layer = [image(:,:,1) image(:,:,2) image(:,:,3)]
+key = im2double(imread('key.jpg'));
+key = [key(:,:,1) key(:,:,2) key(:,:,3)]
+layer = [inv(key[1] * layer[1]) inv(key[2] * layer[2]) inv(key[2] * layer[2])]
+final(:,:,1) = layer[1]
+final(:,:,2) = layer[2]
+final(:,:,3) = layer[3]
 imshow(final);
 DestinationDir='*Insert destination*';
 imwrite(final,strcat(DestinationDir,'DecryptedImage.jpg'));


### PR DESCRIPTION
use layer[] instead of layer1, layer2, layer3
use key[] instead of key1, key2, key3
remove redundant function calls